### PR TITLE
fix: quote step name in deploy workflow

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -69,7 +69,7 @@ jobs:
           fi
           echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
 
-      - name: Build and Push image (doble tag: SHA + version)
+      - name: "Build and Push image (doble tag: SHA + version)"
         env:
           PROJECT_ID: ${{ env.PROJECT_ID }}
           REGION:     ${{ env.REGION }}


### PR DESCRIPTION
## Summary
- quote Build and Push image step name so colon is parsed correctly

## Testing
- `gh workflow run deploy-cloudrun.yml` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b13b36e9a88332b781c2733a8121cf