### PR TITLE
chore: remove colon from build step name

### DIFF
--- a/.github/workflows/deploy-cloudrun.yml
+++ b/.github/workflows/deploy-cloudrun.yml
@@ -69,7 +69,7 @@ jobs:
           fi
           echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
       
-      - name: "Build and Push image (doble tag: SHA + version)"
+      - name: 'Build and Push image (doble tag SHA + version)'
         env:
           PROJECT_ID: ${{ env.PROJECT_ID }}
           REGION:     ${{ env.REGION }}


### PR DESCRIPTION
## Summary
- rename Docker build step to avoid colon in workflow name

## Testing
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy-cloudrun.yml'); puts 'YAML OK'"`
- `pip install yamllint` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b149b1257883329e32a91d18199c4f