### PR TITLE
feat: align runtime with app repo

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,5 +25,5 @@ steps:
         "--platform", "managed",
         "--allow-unauthenticated",
         "--service-account", "${_RUNTIME_SA}",
-        "--set-secrets", "GEMINI_API_KEY=GEMINI_API_KEY:latest"
+        "--set-secrets", "API_KEY=API_KEY:latest,GITHUB_TOKEN=GITHUB_TOKEN:latest"
       ]

--- a/infra/package.json
+++ b/infra/package.json
@@ -2,6 +2,10 @@
   "name": "aire-guardianes-runtime",
   "private": true,
   "type": "module",
+  "engines": { "node": "20.x" },
+  "scripts": {
+    "start": "node server.js"
+  },
   "dependencies": {
     "express": "^4.19.2"
   }

--- a/infra/server.js
+++ b/infra/server.js
@@ -3,6 +3,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 
 const app = express();
+app.set("trust proxy", true);
 const port = process.env.PORT || 8080;
 
 // Resolve absolute paths (ESM-compatible __dirname)
@@ -12,18 +13,19 @@ const distDir = path.join(__dirname, "dist");
 const indexHtml = path.join(distDir, "index.html");
 
 // Parse JSON bodies for API endpoints
-app.use(express.json({ limit: "2mb" }));
+app.use(express.json({ limit: "50mb" }));
 
 // Health endpoints for Cloud Run and probes
+app.get("/healthy", (_req, res) => res.status(200).type("text/plain").send("ok"));
 app.get("/healthz", (_req, res) => res.status(200).type("text/plain").send("ok"));
 app.get("/_ah/health", (_req, res) => res.status(200).type("text/plain").send("ok"));
 
-// Minimal proxy to Gemini API (same contract as app/server.js)
+// Proxy to Google Gemini API
 app.post("/api/gemini/generate", async (req, res) => {
   try {
-    const API_KEY = process.env.GEMINI_API_KEY;
+    const API_KEY = process.env.API_KEY;
     if (!API_KEY) {
-      return res.status(500).json({ error: "GEMINI_API_KEY not configured" });
+      return res.status(500).json({ error: "API_KEY not configured" });
     }
     const { model = "gemini-1.5-flash", ...rest } = req.body || {};
     const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${API_KEY}`;
@@ -33,6 +35,52 @@ app.post("/api/gemini/generate", async (req, res) => {
       body: JSON.stringify(rest),
     });
     const ct = r.headers.get("content-type") || "application/json";
+    const txt = await r.text();
+    res.status(r.status).type(ct).send(txt);
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// Proxy to GitHub API for gallery operations
+app.all("/api/github/*", async (req, res) => {
+  try {
+    const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+    if (!GITHUB_TOKEN) {
+      return res.status(500).json({ error: "GITHUB_TOKEN not configured" });
+    }
+    const target = `https://api.github.com/${req.params[0]}${req.url.includes('?') ? '?' + req.url.split('?')[1] : ''}`;
+    const r = await fetch(target, {
+      method: req.method,
+      headers: {
+        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        "content-type": req.headers["content-type"] || "application/json",
+        Accept: req.headers["accept"] || "application/vnd.github+json",
+      },
+      body: ["GET", "HEAD"].includes(req.method) ? undefined : JSON.stringify(req.body),
+    });
+    const ct = r.headers.get("content-type") || "application/json";
+    const txt = await r.text();
+    res.status(r.status).type(ct).send(txt);
+  } catch (e) {
+    console.error(e);
+    res.status(500).json({ error: String(e) });
+  }
+});
+
+// Read-only proxy for external CSV/JSON files
+app.get("/api/proxy", async (req, res) => {
+  try {
+    const url = req.query.url;
+    if (!url || typeof url !== "string") {
+      return res.status(400).json({ error: "url query parameter required" });
+    }
+    const r = await fetch(url);
+    const ct = r.headers.get("content-type") || "";
+    if (!/^application\/json|text\/csv/.test(ct)) {
+      return res.status(400).json({ error: "unsupported content-type" });
+    }
     const txt = await r.text();
     res.status(r.status).type(ct).send(txt);
   } catch (e) {


### PR DESCRIPTION
## Summary
- trust upstream proxies and bump JSON limit to 50 MB
- expose new API proxies for GitHub, Gemini and CSV/JSON reads
- map API_KEY and GITHUB_TOKEN secrets in Cloud Build

## Testing
- `npm test --prefix infra` *(fails: Missing script "test")*
- `npm install --prefix infra` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e9b58a8c8332a2b8e2d737c9f198