### PR TITLE
Replace npm ci with npm install in builder stage

### DIFF
--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:20 AS builder
 WORKDIR /app
 COPY app/package*.json ./
-RUN npm ci --include=dev || npm install --include=dev --legacy-peer-deps
+RUN npm install --include=dev --legacy-peer-deps
 COPY app/ .
 ENV NODE_OPTIONS=--openssl-legacy-provider
 # Strip dev-only importmap and stray index.css link to avoid Vite/Rollup unresolved externals


### PR DESCRIPTION
## Summary
- use `npm install` in infra Dockerfile builder stage to avoid requiring a lockfile

## Testing
- `node infra/server.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68b9746020688332a54616df3ba73de7