### PR TITLE
fix: ensure package.json is valid

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -6,18 +6,18 @@
     "": {
       "name": "aire-guardianes-app",
       "version": "1.0.0",
-      "dependencies": {
-        "phone": "14.7.77",
-        "uuid": "9.0.1"
+        "dependencies": {
+          "uuid": "9.0.1",
+          "phone": "14.7.77"
+        }
+      }
+    },
+    "dependencies": {
+      "uuid": {
+        "version": "9.0.1"
+      },
+      "phone": {
+        "version": "14.7.77"
       }
     }
-  },
-  "dependencies": {
-    "phone": {
-      "version": "14.7.77"
-    },
-    "uuid": {
-      "version": "9.0.1"
-    }
   }
-}

--- a/app/package.json
+++ b/app/package.json
@@ -7,7 +7,7 @@
     "build": "mkdir -p dist && cp index.html dist/index.html"
   },
   "dependencies": {
-    "phone": "14.7.77",
-    "uuid": "9.0.1"
+    "uuid": "9.0.1",
+    "phone": "14.7.77"
   }
 }


### PR DESCRIPTION
## Summary
- reformat dependency list to keep package.json valid
- sync package-lock.json with package.json

## Testing
- `npm install --include=dev --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/phone)*

------
https://chatgpt.com/codex/tasks/task_e_68b987514b18833297d83b63f9007b82